### PR TITLE
Update color typography

### DIFF
--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -1,18 +1,62 @@
 :root {
-  --white-color: #ffffff;
-  --black-color: #000000;
+  --white: #ffffff;
+  --black: #000000;
 
-  --primary-50-color: #F6FDFF;
-  --primary-100-color: #D5F6FF;
-  --primary-200-color: #A6EEFF;
-  --primary-300-color: #14D9FA;
-  --primary-400-color: #00BCDA;
-  --primary-500-color: #009FB9;
-  --primary-600-color: #008399;
-  --primary-700-color: #00687A;
-  --primary-800-color: #004E5C;
-  --primary-900-color: #003640;
-  --primary-950-color: #001F26;
+  --bg: #0E1212;
+
+  --light-04: #FFFFFF0A;
+  --light-08: #FFFFFF14;
+  --light-12: #FFFFFF1F;
+
+  --primary-50: #FAFCFC;
+  --primary-100: #F2F4F5;
+  --primary-200: #DCE5E5;
+  --primary-300: #C5CFD1;
+  --primary-400: #A8B1B2;
+  --primary-500: #808B8C;
+  --primary-600: #555E61;
+  --primary-700: #3F4747;
+  --primary-800: #2A3234;
+  --primary-850: #212729;
+  --primary-900: #1A1E20;
+  --primary-950: #141819;
+
+  --green-100: #F7FFEF;
+  --green-200: #EAFFD4;
+  --green-300: #DCFFB4;
+  --green-400: #CAFF82;
+  --green-500: #B2FF42;
+  --green-600: #77BC23;
+  --green-700: #588E1A;
+  --green-800: #3B6413;
+  --green-900: #243C0C;
+
+  --dark-green-100: #E6F4F3;
+  --dark-green-200: #BCE4DF;
+  --dark-green-300: #90CDC7;
+  --dark-green-400: #59AEA3;
+  --dark-green-500: #0D8773;
+  --dark-green-600: #085B4C;
+  --dark-green-700: #064438;
+  --dark-green-800: #043029;
+  --dark-green-900: #021D19;
+
+
+  --pink-100: #FFEDFD;
+  --pink-200: #FFD5FB;
+  --pink-300: #FFB1F7;
+  --pink-400: #FE80F2;
+  --pink-500: #FE42EB;
+  --pink-600: #A923B1;
+  --pink-700: #7E1A82;
+  --pink-800: #54125F;
+  --pink-900: #340B3A;
+
+  --green-gradient-40:  linear-gradient(90deg, rgba(178, 255, 66, 0.4) 0%, rgba(13, 135, 115, 0.4) 100%);
+  --green-gradient-100:  linear-gradient(90deg, #B2FF42 0%, #0D8773 100%);
+
+  --pink-gradient-40: linear-gradient(90deg, rgba(255, 66, 224, 0.4) 0%, rgba(94, 13, 135, 0.4) 100%);
+  --pink-gradient-100:  linear-gradient(90deg, #FF42E0 0%, #5E0D87 100%);
 
   --secondary-50-color: #FFFBF7;
   --secondary-100-color: #FFF0C6;

--- a/src/styles/colors.css
+++ b/src/styles/colors.css
@@ -1,7 +1,4 @@
 :root {
-  --white: #ffffff;
-  --black: #000000;
-
   --bg: #0E1212;
 
   --light-04: #FFFFFF0A;
@@ -57,6 +54,23 @@
 
   --pink-gradient-40: linear-gradient(90deg, rgba(255, 66, 224, 0.4) 0%, rgba(94, 13, 135, 0.4) 100%);
   --pink-gradient-100:  linear-gradient(90deg, #FF42E0 0%, #5E0D87 100%);
+
+  /* Old design Colors starts here */
+
+  --white-color: #ffffff;
+  --black-color: #000000;
+
+  --primary-50-color: #F6FDFF;
+  --primary-100-color: #D5F6FF;
+  --primary-200-color: #A6EEFF;
+  --primary-300-color: #14D9FA;
+  --primary-400-color: #00BCDA;
+  --primary-500-color: #009FB9;
+  --primary-600-color: #008399;
+  --primary-700-color: #00687A;
+  --primary-800-color: #004E5C;
+  --primary-900-color: #003640;
+  --primary-950-color: #001F26;
 
   --secondary-50-color: #FFFBF7;
   --secondary-100-color: #FFF0C6;
@@ -117,4 +131,6 @@
   --neural-variant-800-color: #3F484B;
   --neural-variant-900-color: #293234;
   --neural-variant-950-color: #141D1F;
+
+  /* Old design Colors ends here */
 }

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -1,13 +1,11 @@
 @import url('https://fonts.googleapis.com/css2?family=Inter:wght@100;200;300;400;500;600;700;800;900&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Manrope:wght@200;400;600;700;800&display=swap');
 @import './colors.css';
 @import './breakpoints.css';
 @import './typography.css';
 
-html,
-body {
-  padding: 0;
-  margin: 0;
-  font-family: 'Inter',
+:root {
+  --font-family-inter: 'Inter',
   -apple-system,
   BlinkMacSystemFont,
   Segoe UI,
@@ -19,6 +17,14 @@ body {
   Droid Sans,
   Helvetica Neue,
   sans-serif;
+  --font-family-manrope: 'Manrope', sans-serif;
+}
+
+html,
+body {
+  padding: 0;
+  margin: 0;
+  font-family: var(--font-family-manrope);
   scroll-behavior: smooth;
   scroll-padding-top: 6rem;
 }

--- a/src/styles/typography.css
+++ b/src/styles/typography.css
@@ -4,36 +4,132 @@
 .h-500,
 .h-400,
 .h-300,
-.h-200 {
-  font-weight: bold;
+.h-200,
+.h-100,
+.subtitle-bold {
+  font-weight: 700;
+  letter-spacing: -0.04em;
+}
+
+.h-600,
+.h-500,
+.h-300,
+.subtitle-bold  {
+  line-height: 1.2em;
+}
+
+.h-200,
+.h-100 {
+  line-height: 1.24em;
   letter-spacing: -0.02em;
-  line-height: 108%;
+}
+
+
+.subtitle-bold,
+.text-lg--short,
+.text-lg--long, 
+.text-md--short,
+.text-md--long,
+.caption--semi-bold {
+  letter-spacing: -0.01em;
 }
 
 .h-600 {
-  font-size: 4rem;
-  line-height: 106%;
+  font-size: 3.583rem;
 }
-
 .h-500 {
-  font-size: 3.25rem;
-  line-height: 111%;
+  font-size: 2.986rem;
 }
 
 .h-400 {
-  font-size: 2.5rem;
+  font-size: 2.488rem;
+  line-height: 1.18em;
 }
 
 .h-300 {
-  font-size: 1.875rem;
+  font-size: 2.074rem;
 }
 
 .h-200 {
-  font-size: 1.5rem;
-  line-height: 116%;
+  font-size: 1.728rem;
 }
 
+.h-100 {
+  font-size: 1.440rem;
+}
+
+/* .h-100 {
+  font-size: 1.200rem;
+} */
+
 /* Subtitles */
+
+.subtitle-bold {
+  font-size: 1.200rem;
+}
+
+/* Texts */
+.text-md--long,
+.text-md--short,
+.text-lg--short,
+.text-lg--short {
+  font-weight: 400;
+}
+
+.text-lg--short, 
+.text-md--short {
+  line-height: 1.28em;
+}
+
+.text-lg--short,
+.text-lg--short {
+  font-size: 1rem;
+}
+
+.text-lg--long{
+  line-height: 1.64em;
+}
+
+.text-md--long,
+.text-md--short,
+.btn--extra-bold {
+  font-size: 0.833rem;
+}
+
+.text-md--long{
+  line-height: 1.7em;
+}
+
+.caption--semi-bold, 
+.overline--extra-bold,
+.btn-sm--extra-bold {
+  font-size: 0.694rem;
+}
+
+.caption--semi-bold,
+.btn--extra-bold {
+  line-height: 1.14em;
+}
+/* Caption */
+
+.caption--semi-bold {
+  font-weight: 600;
+}
+
+.btn--extra-bold, 
+.overline--extra-bold,
+.btn-sm--extra-bold {
+  font-weight: 800;
+  letter-spacing: 0.04em;
+}
+
+/* Overline */
+.overline--extra-bold,
+.btn-sm--extra-bold {
+  line-height: 1.16em;
+}
+
+/* Old typography starts here */
 
 .subtitle-01,
 .subtitle-02 {
@@ -141,3 +237,4 @@
   font-size: 0.75rem;
   line-height: 0.75rem;
 }
+/* Old typography ends here */


### PR DESCRIPTION
As a developer I would like the global colors and typography to be updated to the latest Web 3 designs

NOTE: the branch needs to be merged into a new branch called "redesign" otherwise it will break the live site!

Ac:
- [x] Update the files with the information provided by the designers (JUST THE STYLE SECTION OF THE ATTACHED PAGE)


Figma page with info: https://www.figma.com/file/bQARkk82bZF5XxoVft8EaF/BE-library?node-id=9294%3A48222