### PR TITLE
Remove next btn from last page

### DIFF
--- a/src/components/PagePaginationLink/PagePaginationLink.jsx
+++ b/src/components/PagePaginationLink/PagePaginationLink.jsx
@@ -9,6 +9,8 @@ import navbarLinks from '@/data/navbarLinks.yaml';
 
 export default function PagePaginationLink({ link, navDirection, text, ...props }) {
   const [isLastLink, setIsLastLink] = React.useState(false);
+  const router = useRouter();
+
   const pagePagination = clsx(styles.pagePagination, {
     [styles.prevButton]: navDirection === 'previous',
   });
@@ -17,11 +19,8 @@ export default function PagePaginationLink({ link, navDirection, text, ...props 
     [styles.prevDirection]: navDirection === 'previous',
   });
 
-  const router = useRouter();
-
   React.useEffect(() => {
     const items = navbarLinks.items;
-    console.log(router.pathname.match(new RegExp(items[items.length - 1].href, 'gi')));
     setIsLastLink(router.pathname.match(new RegExp(items[items.length - 1].href, 'gi')) ? true : false);
   }, [link]);
 

--- a/src/components/PagePaginationLink/PagePaginationLink.jsx
+++ b/src/components/PagePaginationLink/PagePaginationLink.jsx
@@ -3,8 +3,12 @@ import PropTypes from 'prop-types';
 import clsx from 'clsx';
 import Svg from '../Svg';
 import Link from 'next/link';
+import React from 'react';
+import { useRouter } from 'next/router';
+import navbarLinks from '@/data/navbarLinks.yaml';
 
 export default function PagePaginationLink({ link, navDirection, text, ...props }) {
+  const [isLastLink, setIsLastLink] = React.useState(false);
   const pagePagination = clsx(styles.pagePagination, {
     [styles.prevButton]: navDirection === 'previous',
   });
@@ -12,6 +16,16 @@ export default function PagePaginationLink({ link, navDirection, text, ...props 
   const direction = clsx(styles.direction, {
     [styles.prevDirection]: navDirection === 'previous',
   });
+
+  const router = useRouter();
+
+  React.useEffect(() => {
+    const items = navbarLinks.items;
+    console.log(router.pathname.match(new RegExp(items[items.length - 1].href, 'gi')));
+    setIsLastLink(router.pathname.match(new RegExp(items[items.length - 1].href, 'gi')) ? true : false);
+  }, [link]);
+
+  if (isLastLink) return null;
 
   return (
     <Link href={link} passHref>

--- a/src/layouts/BlogLayout/BlogLayout.jsx
+++ b/src/layouts/BlogLayout/BlogLayout.jsx
@@ -64,7 +64,7 @@ function BlogLayout({ children, pages }) {
                     onClick={() => toggleOptions(false)}
                     className={clsx('btn', styles.leftSidebar__link, slug === page.slug && styles.active)}
                   >
-                    {page.data.title}
+                    <span>{page.data.title}</span>
                   </a>
                 </Link>
               ))}
@@ -90,14 +90,14 @@ function BlogLayout({ children, pages }) {
             {children}
           </div>
           <div className={styles.footer}>
-            {prev_page && pages && (
+            {prev_page && (
               <PagePaginationLink text={`${prev_page.data.title}`} link={prev_page.slug} navDirection="previous" />
             )}
-            {next_page && pages && (
+            {next_page && (
               <PagePaginationLink text={`${next_page.data.title}`} link={next_page.slug} navDirection="next" />
             )}
 
-            {!next_page && pages && <PagePaginationLink text={`Learn`} link={'/learn'} navDirection="next" />}
+            {!next_page && <PagePaginationLink text={`Learn`} link={'/learn'} navDirection="next" />}
           </div>
         </div>
       </div>

--- a/src/layouts/BlogLayout/BlogLayout.jsx
+++ b/src/layouts/BlogLayout/BlogLayout.jsx
@@ -90,14 +90,14 @@ function BlogLayout({ children, pages }) {
             {children}
           </div>
           <div className={styles.footer}>
-            {prev_page && (
+            {prev_page && pages && (
               <PagePaginationLink text={`${prev_page.data.title}`} link={prev_page.slug} navDirection="previous" />
             )}
-            {next_page && (
+            {next_page && pages && (
               <PagePaginationLink text={`${next_page.data.title}`} link={next_page.slug} navDirection="next" />
             )}
 
-            {!next_page && <PagePaginationLink text={`Learn`} link={'/learn'} navDirection="next" />}
+            {!next_page && pages && <PagePaginationLink text={`Learn`} link={'/learn'} navDirection="next" />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
The last page shouldn't have the bottom navigation.
In our case as of now, its the `Ship page`.