### PR TITLE
chore: case studies folder

### DIFF
--- a/src/pages/case-studies/[slug].js
+++ b/src/pages/case-studies/[slug].js
@@ -1,0 +1,7 @@
+import styles from '@/styles/MDX.module.css';
+
+function CaseStudies() {
+  return <div className={styles.container}></div>;
+}
+
+export default CaseStudies;

--- a/src/styles/MDX.module.css
+++ b/src/styles/MDX.module.css
@@ -1,6 +1,7 @@
 .container {
   color: var(--primary-450);
   margin: 0 auto;
+  min-height: 100vh;
 }
 
 .container img {


### PR DESCRIPTION
Allow the abilioty to create internal case studies pages like with blogs

AC:
- [x] Create a new "blog type" page for internal case studies (rendered in https://www.blockchain.education/case-studies/caseStudiesName1)
- [x] The internal site will be currently just available DIRECTLY by inserting the link in the URL and the next ticket will take care of adding it to the case studies